### PR TITLE
Add `make run` command support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: RUN
+.PHONY: run
 
-RUN:
+run:
 	./docker-run.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: RUN
+
+RUN:
+	./docker-run.sh

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - Ensure you have docker [desktop installed locally](https://www.docker.com/products/docker-desktop/).
 - Run `docker login`.
 - Run `docker run -p 8000:8000 --rm -it $(docker build -q .)`.
+    - Optionally, you can run `make run`.
 - Go to http://localhost:8000 in your web browser and view the website locally! 🎉
 
 ## Running the application on a different domain

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,1 @@
+docker run -p 8000:8000 --rm -it $(docker build -q .)


### PR DESCRIPTION
## Summary
- Add `make run` support to run the application locally, as an option.
    - The other option of using `docker run -p 8000:8000 --rm -it $(docker build -q .)` is still available.