### PR TITLE
Add links to meetup and slack group

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dearborn Coding Club's Backend Django Server
 - A backend webserver for serving static assets and handling requests for dearborncodingclub.com.
-- Check out the slack channel [here](https://dearborncodingclub.slack.com/).
-- Check out the meetup group [here](https://dearborncodingclub.slack.com/).
+- Check out the slack channel [here](https://dearborncodingclub.slack.com).
+- Check out the meetup group [here](https://www.meetup.com/dearborn-coding-club).
 
 ## Getting Set Up In Docker (Recommended)
 - Ensure you have docker [desktop installed locally](https://www.docker.com/products/docker-desktop/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Dearborn Coding Club's Backend Django Server
 - A backend webserver for serving static assets and handling requests for dearborncodingclub.com.
+- Check out the slack channel [here](https://dearborncodingclub.slack.com/).
+- Check out the meetup group [here](https://dearborncodingclub.slack.com/).
 
 ## Getting Set Up In Docker (Recommended)
 - Ensure you have docker [desktop installed locally](https://www.docker.com/products/docker-desktop/).


### PR DESCRIPTION
References https://github.com/dearborn-coding-club/website-base-backend/issues/24

## Summary
- Adds reference links for slack and meetup.