### PR TITLE
Add first test; start linting

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,11 +1,16 @@
 from django.db import models
 from rest_framework import serializers
 
+
 class Note (models.Model):
-  title = models.CharField(max_length=100)
-  content = models.TextField()
-  created_at = models.DateTimeField(auto_now_add=True) 
-  updated_at = models.DateTimeField(auto_now=True)
+    title = models.CharField(max_length=100)
+    content = models.TextField()
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    def get_content(self):
+        return self.content
+
 
 class NoteSerializer(serializers.ModelSerializer):
     class Meta:

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,9 @@
 from django.test import TestCase
+from core.models import Note
 
-# Create your tests here.
+
+class NoteSerializerTest(TestCase):
+    def test_note_serializer_works(self):
+        """Animals that can speak are correctly identified"""
+        test_note = Note(content="test_content")
+        self.assertEqual(test_note.get_content(), 'test_content')

--- a/project/views.py
+++ b/project/views.py
@@ -1,7 +1,7 @@
-
 from django.http import JsonResponse
 
-def meetup_view(request):
+
+def meetup_view():
     data = {
         "message": "Welcome to the meetup page!",
         "status": "success"


### PR DESCRIPTION
## Summary
- Starts adding the first test.
- Starts cleaning up the code, using `Flake8` and `Pylint` linters.

## Context
It would be nice to have the test harness working, so we can integrate testing as part of our deployment flow. Right now I'm implementing that using Django's built-in framework. There's only 1 test for now, but we can improve upon it in future PRs. I'd also love to have this be part of CI so we gate merges on passing tests and linters.

## Examples
You can run the test using the command `./manage.py test` and it should pass. 