### PR TITLE
feat(lint): Introduce `Flake8` linter and configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = .git, __pycache__, lib

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
     * [Running with Virtual Env](#running-with-virtual-env-recommended)
     * [Running with Docker](#running-in-docker)
     * [Running migrations](#running-migrations)
+    * [Running linters](#running-linters)
 3. [Deploying to Fly.io](#deploying-to-flyio)
 4. [Regenerating Certs](#regenerating-tls-certificates)
 5. [Running on a different domain](#running-the-application-on-a-different-domain)
@@ -86,6 +87,10 @@ website-base-backend/
 In order to run locally with a correctly seeded database, you'll need to run migrations. In order to do this, run the following command.
 
 `./managy.py migrate`
+
+### Running Linters
+---
+To run the linters, execute the `flake8` command.
 
 ### Deploying to Fly.io
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,9 @@ asgiref==3.8.1
 Django==5.0.4
 django-cors-headers==4.3.1
 djangorestframework==3.15.2
+flake8==7.1.1
+mccabe==0.7.0
+psycopg2-binary==2.9.9
+pycodestyle==2.12.1
+pyflakes==3.2.0
 sqlparse==0.5.1


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-backend/issues/83

## Summary
- Introduces the `Flake8` Python code linter and its configuration
- Adds missing dependency configuration. This was added using the `pip freeze > requirements.txt` command.
- Updates the `README.md` to include instructions on how to run the linter.

## Background
We need a linter to keep code quality at a certain level. This introduces the dependency and adds documentation for how to run it. In the future, we can make this a Husky `pre-commit` hook, as well as add it to CI as a check.

## Screenshots
N/A