### PR TITLE
fix: Remove secret key from `settings.py` source code

### DIFF
--- a/public_api/settings.py
+++ b/public_api/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-j*1@f05-)o5!3+^kzs@r#y+$atj=!0q#rv%5wr34%3*3qw_d60'
+SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-backend/issues/101

## Context
We've needed to remove the secret key from our source code for a while. This PR addresses and does that.

## Summary
- Removes the `DJANGO_SECRET_KEY` from our source code, and sources it from the environment.