### PR TITLE
fix: Remove passwords from API response

### DIFF
--- a/accounts/serializers.py
+++ b/accounts/serializers.py
@@ -12,4 +12,5 @@ class UserSerializer(serializers.ModelSerializer):
     profile = ProfileSerializer()
     class Meta:
         model = DCCUser
-        fields = ['id', 'profile', 'password', 'last_login', 'is_superuser', 'username', 'first_name', 'last_name', 'email', 'is_staff', 'is_active', 'bio', 'date_joined', 'bio', 'birthdate']
+        fields = ['id', 'profile', 'last_login', 'is_superuser', 'username', 'first_name', 'last_name', 'email', 'is_staff', 'is_active', 'bio', 'date_joined', 'bio', 'birthdate']
+        extra_kwargs = {'password': {'write_only': True}}


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-backend/issues/120

## Context
After introducing the ability to return user profiles and accounts with this PR, we accidentally added the ability to return the user's passwords along with their general metadata. This is a pretty large security vulnerability and we should investigate removing this. This PR adds an exclusion to the API to remove the password field from being returned with the response.

## Summary
- Removes the `password` field from the `fields` array configuration for the serialized `Profile` object.