### PR TITLE
fix: update psycopg2-binary version to prevent macOS build breaks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ idna==3.10
 jiter==0.8.0
 mccabe==0.7.0
 openai==1.57.0
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
 pycodestyle==2.12.1
 pydantic==2.10.3
 pydantic_core==2.27.1


### PR DESCRIPTION
## Summary
- Updated `psycopg2-binary` version in `requirements.txt` from `2.9.9` to `2.9.10`.

## Context
Attempting to install via README, and build broke on `Error: pg_config executable not found` `error: subprocess-exited-with-error`

<details>
<summary>Click to expand error</summary>

``` bash
Collecting psycopg2-binary==2.9.9 (from -r requirements.txt (line 18))
  Using cached psycopg2-binary-2.9.9.tar.gz (384 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [21 lines of output]
      running egg_info
      writing psycopg2_binary.egg-info/PKG-INFO
      writing dependency_links to psycopg2_binary.egg-info/dependency_links.txt
      writing top-level names to psycopg2_binary.egg-info/top_level.txt

      Error: pg_config executable not found.

      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:

          python setup.py build_ext --pg-config /path/to/pg_config build ...

      or with the pg_config option in 'setup.cfg'.

      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.

      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).

      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```
</details>

