### PR TITLE
feat(api): Introduce JWT authentication to all endpoints

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets, status
+from rest_framework import viewsets
 from .models import Profile, DCCUser
 import requests
 from rest_framework.response import Response

--- a/public_api/authenticate.py
+++ b/public_api/authenticate.py
@@ -1,0 +1,39 @@
+"""Custom authentication class for the API."""
+import os
+from rest_framework import authentication
+from rest_framework import exceptions
+import jwt
+
+
+class CustomAuthentication(authentication.BaseAuthentication):
+    """Custom authentication class for the API."""
+    def authenticate(self, request):
+        auth_header = request.META.get('HTTP_AUTHORIZATION')
+
+        try:
+            jwt_secret = os.environ['JWT_SECRET']
+        except KeyError:
+            raise exceptions.AuthenticationFailed('JWT_SECRET not set')
+
+        if not auth_header or not auth_header.startswith('Bearer '):
+            # This doesn't seem to hit the latter half of the if statement
+            # Even when the Bearer token is missing.
+            raise exceptions.AuthenticationFailed('Authentication failed, no auth header')
+        token = auth_header.split(' ')[1]
+
+        if not token:
+            raise exceptions.AuthenticationFailed('Authentication failed, no token')
+
+        try:
+            jwt.decode(token, jwt_secret, algorithms=['HS256'])
+        except jwt.ExpiredSignatureError as e:
+            raise exceptions.AuthenticationFailed('Token has expired' + e)
+        except jwt.InvalidTokenError as e:
+            # Note: If you pass the iat field, it must be a valid timestamp (not too far in the future,
+            # not too far in the past. If you don't pass it, it will be ignored.
+            # If the above happens, it throws an `ImmatureSignatureError` exception.
+            raise exceptions.AuthenticationFailed('Invalid token' + e)
+        except jwt.InvalidSignatureError as e :
+            raise exceptions.AuthenticationFailed('Invalid signature' + e)
+        except Exception as e:
+            raise exceptions.AuthenticationFailed('Authentication' + e)

--- a/public_api/settings.py
+++ b/public_api/settings.py
@@ -87,6 +87,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'public_api.wsgi.application'
 
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'public_api.authenticate.CustomAuthentication',
+    ),
+}
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pycodestyle==2.12.1
 pydantic==2.10.3
 pydantic_core==2.27.1
 pyflakes==3.2.0
+PyJWT==2.10.1
 requests==2.32.3
 sniffio==1.3.1
 sqlparse==0.5.1


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-backend/issues/132

## Summary
- Adds a new `CustomAuthentication` class as the default Django authentication class. This class adds automatic `Authentication` header checking on each request to the Python app (`api.dearborncodingclub.com`) - this provides more security around sensitive user information.

## Context
We've set up our infra to have our own custom authentication, but we're not checking against it in any of our Django backend APIs. To explain further, our current login process returns a JWT token for the user to consume. After their browser has stored the token in their local storage, the token _should_ be sent as part of the header to all subsequent requests to the Python / Django backend. This isn't currently happening yet, but with this PR we can hopefully move towards that future 🤞🏾.