### PR TITLE
fix: Remove JSONViewer default when not running in `DEBUG` mode

### DIFF
--- a/public_api/authenticate.py
+++ b/public_api/authenticate.py
@@ -33,7 +33,8 @@ class CustomAuthentication(authentication.BaseAuthentication):
             # not too far in the past. If you don't pass it, it will be ignored.
             # If the above happens, it throws an `ImmatureSignatureError` exception.
             raise exceptions.AuthenticationFailed('Invalid token' + e)
-        except jwt.InvalidSignatureError as e :
+        except jwt.InvalidSignatureError as e:
             raise exceptions.AuthenticationFailed('Invalid signature' + e)
         except Exception as e:
             raise exceptions.AuthenticationFailed('Authentication' + e)
+        return (user, None)

--- a/public_api/settings.py
+++ b/public_api/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 AUTH_USER_MODEL = 'accounts.DCCUser'  # 'app_name.ModelName'
 
@@ -91,7 +91,12 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'public_api.authenticate.CustomAuthentication',
     ),
+    'DEFAULT_RENDERER_CLASSES': (
+        'rest_framework.renderers.JSONRenderer' if not DEBUG else 'rest_framework.renderers.BrowsableAPIRenderer',
+    )
 }
+
+
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-backend/issues/134

## Summary
- Disables `BrowsableAPIRenderer` by default and enables it only when `DEBUG` is set to `True` in the Django settings.

## Context
We currently enable the Django `BrowsableAPIRenderer` that's part of the Django Rest Framework by default, but I think it might be better to just disable it. This PR disables it by default, but allows it to be enabled by setting `DEBUG` to `True`.

## Screenshots
<img width="1323" alt="Screenshot 2025-03-09 at 4 42 51 PM" src="https://github.com/user-attachments/assets/fe77ca11-50f0-4da9-a761-749ff12cd2d9" />
