### PR TITLE
feat: Add `/me` endpoint

### DIFF
--- a/public_api/authenticate.py
+++ b/public_api/authenticate.py
@@ -10,6 +10,12 @@ class CustomAuthentication(authentication.BaseAuthentication):
     def authenticate(self, request):
         auth_header = request.META.get('HTTP_AUTHORIZATION')
 
+        print("auth_header", auth_header)
+        if request.path == 'me/':
+            user_id = "some id"
+            print("/me/ pathfdsds")
+            return (CustomUser(user_id), None)
+
         try:
             jwt_secret = os.environ['JWT_SECRET']
         except KeyError:
@@ -37,4 +43,18 @@ class CustomAuthentication(authentication.BaseAuthentication):
             raise exceptions.AuthenticationFailed('Invalid signature' + e)
         except Exception as e:
             raise exceptions.AuthenticationFailed('Authentication' + e)
-        return (user, None)
+        return (None, None)
+    
+    def get_user_id_from_request(self, request):
+        # Logic to extract user ID from the request (e.g., from a query parameter or session)
+        # For simplicity, returning a mock user ID
+        return {'id': 1}  # Replace with actual logic
+
+
+class CustomUser:
+    def __init__(self, user_id):
+        self.id = user_id
+
+    @property
+    def is_authenticated(self):
+        return True

--- a/public_api/authenticate.py
+++ b/public_api/authenticate.py
@@ -6,20 +6,26 @@ import jwt
 
 
 class CustomAuthentication(authentication.BaseAuthentication):
-    """Custom authentication class for the API."""
+    """
+    Custom authentication class for the API.
+    """
+    public_endpoints = [
+        'profile/'
+    ]
+
     def authenticate(self, request):
+        """
+        Authenticate the user using JWT.
+        """
         auth_header = request.META.get('HTTP_AUTHORIZATION')
 
-        print("auth_header", auth_header)
-        if request.path == 'me/':
-            user_id = "some id"
-            print("/me/ pathfdsds")
-            return (CustomUser(user_id), None)
+        if request.path in self.public_endpoints:
+            return (None, None)
 
         try:
             jwt_secret = os.environ['JWT_SECRET']
-        except KeyError:
-            raise exceptions.AuthenticationFailed('JWT_SECRET not set')
+        except KeyError as exc:
+            raise exceptions.AuthenticationFailed('JWT_SECRET not set', exc)
 
         if not auth_header or not auth_header.startswith('Bearer '):
             # This doesn't seem to hit the latter half of the if statement
@@ -43,18 +49,19 @@ class CustomAuthentication(authentication.BaseAuthentication):
             raise exceptions.AuthenticationFailed('Invalid signature' + e)
         except Exception as e:
             raise exceptions.AuthenticationFailed('Authentication' + e)
-        return (None, None)
-    
-    def get_user_id_from_request(self, request):
-        # Logic to extract user ID from the request (e.g., from a query parameter or session)
-        # For simplicity, returning a mock user ID
-        return {'id': 1}  # Replace with actual logic
+        return (token, None)
 
 
 class CustomUser:
+    """
+    Custom user class for the API.
+    """
     def __init__(self, user_id):
         self.id = user_id
 
     @property
     def is_authenticated(self):
+        """
+        Returns True if the user is authenticated.
+        """
         return True

--- a/public_api/new_urls.py
+++ b/public_api/new_urls.py
@@ -1,0 +1,28 @@
+"""
+URL configuration for server project.
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/5.0/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+"""
+from django.contrib import admin
+from django.urls import path
+from . import views
+
+APP_NAME = 'public_api'
+
+urlpatterns = [
+    path('admin/', admin.site.urls),
+    path('notes/', views.notes_view, name='notes'),
+    path('leetcode/', views.leetcode_view, name="leetcode"),
+    path('me/', views.me_view, name="me"),
+]

--- a/public_api/settings.py
+++ b/public_api/settings.py
@@ -51,7 +51,8 @@ INSTALLED_APPS = [
     'core',
     "corsheaders",
     'rest_framework',
-    'accounts'
+    'accounts',
+    'public_api'
 ]
 
 MIDDLEWARE = [
@@ -64,7 +65,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.common.CommonMiddleware',
 ]
 
 ROOT_URLCONF = 'public_api.urls'
@@ -95,8 +95,6 @@ REST_FRAMEWORK = {
         'rest_framework.renderers.JSONRenderer' if not DEBUG else 'rest_framework.renderers.BrowsableAPIRenderer',
     )
 }
-
-
 
 # Database
 # https://docs.djangoproject.com/en/5.0/ref/settings/#databases

--- a/public_api/urls.py
+++ b/public_api/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('notes/', views.notes_view, name='notes'),
     path('leetcode/', views.leetcode_view, name="leetcode"),
+    path('me/', views.me_view, name="me"),
     path('', include('core.urls')),
     path('', include('accounts.urls'))
 ]

--- a/public_api/urls.py
+++ b/public_api/urls.py
@@ -18,11 +18,10 @@ from django.contrib import admin
 from django.urls import path, include
 from . import views
 
+app_name = 'public_api'
+
 urlpatterns = [
-    path('admin/', admin.site.urls),
-    path('notes/', views.notes_view, name='notes'),
-    path('leetcode/', views.leetcode_view, name="leetcode"),
-    path('me/', views.me_view, name="me"),
+    path('', include('public_api.new_urls')),
     path('', include('core.urls')),
     path('', include('accounts.urls'))
 ]

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -1,8 +1,42 @@
-from django.http import HttpRequest, HttpResponse, JsonResponse
-from django.shortcuts import render
+"""
+Views for API resources that don't require the django rest framework.
+"""
+from functools import wraps
+from django.http import HttpResponse, HttpRequest, JsonResponse
 import requests
+import os
+import jwt
+
+# python3 -m pip install types-requests ## install stubs for type hinting
 
 
+def authentication_required(view_func):
+    """
+      Decorator to check if the user is authenticated.
+    """
+    @wraps(view_func)
+    def _wrapped_view(request, *args, **kwargs):
+        # Example: Check if the user is authenticated
+        if not request.user.is_authenticated:
+            return JsonResponse({"error": "Authentication required"}, status=401)
+        
+        # If authenticated, proceed to the view
+        return view_func(request, *args, **kwargs)
+    return _wrapped_view
+
+
+def no_authentication_required(view_func):
+    """
+    Decorator to explicitly allow access without authentication.
+    """
+    @wraps(view_func)
+    def _wrapped_view(request, *args, **kwargs):
+        # No authentication checks, just call the view
+        return view_func(request, *args, **kwargs)
+    return _wrapped_view
+
+
+@authentication_required
 def notes_view(_: HttpRequest) -> JsonResponse:
     data = {
         "message": "Welcome to the meetup page!",
@@ -40,8 +74,39 @@ def leetcode_view(_: HttpRequest) -> JsonResponse:
     return JsonResponse(response.json())
 
 
-def me_view(req: HttpRequest) -> JsonResponse:
-    if req.user and hasattr(req.user, 'id'):
-        return JsonResponse({"user": req.user.id})
+@no_authentication_required
+def me_view(req: HttpRequest) -> JsonResponse | HttpResponse:
+    """
+    View for the /me endpoint. It reads the Authorization header and checks if the JWT token is valid.
+    """
+    try:
+        jwt_secret = os.environ['JWT_SECRET']
+    except KeyError:
+        return HttpResponse("JWT_SECRET not set", status=500)
 
-    return JsonResponse({"error": "User not authenticated"}, status=401)
+    auth_header = req.META.get("HTTP_AUTHORIZATION")
+
+    if not auth_header or not auth_header.startswith('Bearer '):
+        # This doesn't seem to hit the latter half of the if statement
+        # Even when the Bearer token is missing.
+        return HttpResponse('Authentication failed, no auth header', status=401)
+    else:
+        token = auth_header.split(' ')[1]
+    if not token:
+        return HttpResponse('Authentication failed, no token', status=401)
+
+    try:
+        decoded_token = jwt.decode(token, jwt_secret, algorithms=['HS256'])
+    except jwt.ExpiredSignatureError:
+        return HttpResponse('Token has expired', status=401)
+    except jwt.InvalidTokenError:
+        # Note: If you pass the iat field, it must be a valid timestamp (not too far in the future,
+        # not too far in the past. If you don't pass it, it will be ignored.
+        # If the above happens, it throws an `ImmatureSignatureError` exception.
+        return HttpResponse('Invalid token', status=401)
+    except jwt.InvalidSignatureError:
+        return HttpResponse('Invalid signature', status=401)
+    except Exception:
+        return HttpResponse('Authentication', status=401)
+
+    return JsonResponse(decoded_token)

--- a/public_api/views.py
+++ b/public_api/views.py
@@ -10,6 +10,7 @@ def notes_view(_: HttpRequest) -> JsonResponse:
     }
     return JsonResponse(data)
 
+
 def leetcode_view(_: HttpRequest) -> JsonResponse:
     url = "https://leetcode.com/graphql"
     global_data = """
@@ -37,3 +38,10 @@ def leetcode_view(_: HttpRequest) -> JsonResponse:
 """
     response = requests.get(url=url, json={"query": global_data, "variables": {"username": "MgenGlder23"}, "operationName": "userSessionProgress"}, timeout=10)
     return JsonResponse(response.json())
+
+
+def me_view(req: HttpRequest) -> JsonResponse:
+    if req.user and hasattr(req.user, 'id'):
+        return JsonResponse({"user": req.user.id})
+
+    return JsonResponse({"error": "User not authenticated"}, status=401)


### PR DESCRIPTION
Closes https://github.com/dearborn-coding-club/website-base-backend/issues/140

## Summary
- Introduces the GET `/me` endpoint - it doesn't require any parameters or properties to be passed in, however it does read the Authorization header for a valid JWT token. The Authorization header should be in the form:
    - `Authorization: Bearer <token>`

## Context
- We're looking to introduce a way for users to determine who they are, based on what the server returned. This PR introduces an endpoint, `/me`, that allows the user to validate and store what their username is (in addition to any other metadata stored in the token).